### PR TITLE
update CNKI-copy.js

### DIFF
--- a/CNKI-copy.js
+++ b/CNKI-copy.js
@@ -6,7 +6,7 @@
 // @description:zh-CN  解除知网在线阅读时复制限制
 // @author       auko
 // @supportURL   https://github.com/aukocharlie/my-script
-// @include      http://kns.cnki.net*/*/Detail*
+// @include      *://kns.cnki.net*/*/Detail*
 // @grant        none
 // ==/UserScript==
 


### PR DESCRIPTION
修复协议为https时脚本不可用